### PR TITLE
Add Spring Batch Extensions

### DIFF
--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -86,3 +86,13 @@
       spoken_languages:
         - DE
         - EN
+
+- name: Spring Batch Extensions
+  url: https://github.com/spring-projects/spring-batch-extensions
+  description: The Spring Batch Extensions project provides extension modules for Spring Batch.
+  leads:
+    - name: Stefano Cordio
+      profile_url: https://github.com/scordio
+      spoken_languages:
+        - EN
+        - IT


### PR DESCRIPTION
I recently became co-maintainer of [Spring Batch Extensions](https://github.com/spring-projects/spring-batch-extensions), and I'd be happy to offer it as an additional option for the event.

I'm raising this PR as a draft since I'm waiting for confirmation from the Spring Batch project lead that they are fine sponsoring it at the event.